### PR TITLE
BugFix: update for R to latest R version on AWS repo added

### DIFF
--- a/R/Hadoop/emR_bootstrap.sh
+++ b/R/Hadoop/emR_bootstrap.sh
@@ -85,6 +85,8 @@ while [ $# -gt 0 ]; do
 	shift
 done
 
+# install latest R version from AWS Repo
+sudo yum update R-base -y
 
 # create rstudio user on all machines
 # we need a unix user with home directory and password and hadoop permission


### PR DESCRIPTION
BugFix:

On the EMR AMI default R version is 3.0.2 . Due to the new R release version 3.1.1 the R package "lazyeval" does not work any more with R 3.0.2 (you can not install it) )-:

Solution: in the AWS yum package repo there is already the new R Version 3.1.1 added. I now on default update R to the latest R version in the AWS yum repo.
