### PR TITLE
Update drill bootstrap to work with latest AMIs, and install Drill 0.7

### DIFF
--- a/drill/setup_drill
+++ b/drill/setup_drill
@@ -72,7 +72,7 @@ drill.exec: {
   },
   zk: {
         connect: "#{zookeeperConnect}",
-        root: "/drill",
+        root: "drill",
         refresh: 500,
         timeout: 5000,
         retry: {
@@ -201,9 +201,9 @@ end
 end
 
 def installDrill(targetDir, runDir, logDir)
-    drillTarGZUrl="http://people.apache.org/~jacques/apache-drill-1.0.0-m1.rc3"
-    drillTarGZ="apache-drill-1.0.0-m1-binary-release.tar.gz"
-    drillRoot="apache-drill-1.0.0-m1"
+    drillTarGZUrl="http://getdrill.org/drill/download"
+    drillTarGZ="apache-drill-0.7.0.tar.gz"
+    drillRoot="apache-drill-0.7.0"
 
     println "Going to download Apache Drill distribution #{drillTarGZ} from #{drillTarGZUrl}"
     sudo "curl -L --silent --show-error --fail --connect-timeout 60 --max-time 720 --retry 5 -O  #{drillTarGZUrl}/#{drillTarGZ}"
@@ -224,10 +224,6 @@ def installDrill(targetDir, runDir, logDir)
     sudo "chown -R hadoop.hadoop #{logDir}"
 
     writeDrillConfs($runDir,$logDir)
-
-    println "Installing openjdk1.7"
-    sudo "yum -y install java-1.7.0-openjdk"
-    sudo "alternatives --set java /usr/lib/jvm/jre-1.7.0-openjdk.x86_64/bin/java"
 
     sudo "chown -R hadoop.hadoop #{runDir}"
     sudo "chown -R hadoop.hadoop #{logDir}"


### PR DESCRIPTION
Testing with the latest Drill release as of this moment (0.7), and the latest AMI (3.3.1) I encountered several issues. This PR fixes them:
* Use apache-drill-0.7.0 distribution
* yum is no longer used for package management on AMIs, but java7 is now the default, so java installation is no longer needed.
* Zookeeper root has changed in Drill.