### PR TITLE
Use correct path for ganglia conf file

### DIFF
--- a/spark/install-ganglia-metrics
+++ b/spark/install-ganglia-metrics
@@ -49,6 +49,6 @@ bash configure-spark.bash spark.metrics.conf=/home/hadoop/spark/conf/ganglia.met
 #restart local gmond and gmetad if present
 sudo pkill gmeta
 sudo pkill gmond
-sudo /usr/sbin/gmond -c /etc/gmond.conf
+sudo /usr/sbin/gmond -c /etc/ganglia/gmond.conf
 
 exit 0

--- a/spark/install-ganglia-metrics
+++ b/spark/install-ganglia-metrics
@@ -49,6 +49,13 @@ bash configure-spark.bash spark.metrics.conf=/home/hadoop/spark/conf/ganglia.met
 #restart local gmond and gmetad if present
 sudo pkill gmeta
 sudo pkill gmond
-sudo /usr/sbin/gmond -c /etc/ganglia/gmond.conf
+
+CONF_FILE=/etc/ganglia/gmond.conf
+if [ -e /etc/gmond.conf ]
+then
+    CONF_FILE=/etc/gmond.conf
+fi
+
+sudo /usr/sbin/gmond -c $CONF_FILE
 
 exit 0


### PR DESCRIPTION
If ganglia reporting is enabled via the "-g" flag to the install-spark action, this incorrect path causes the ganglia monitor to restart incorrectly, breaking metrics reporting for the entire cluster