### PR TITLE
Update Drill URL to 0.8

### DIFF
--- a/drill/setup_drill
+++ b/drill/setup_drill
@@ -202,8 +202,8 @@ end
 
 def installDrill(targetDir, runDir, logDir)
     drillTarGZUrl="http://getdrill.org/drill/download"
-    drillTarGZ="apache-drill-0.7.0.tar.gz"
-    drillRoot="apache-drill-0.7.0"
+    drillTarGZ="apache-drill-0.8.0.tar.gz"
+    drillRoot="apache-drill-0.8.0"
 
     println "Going to download Apache Drill distribution #{drillTarGZ} from #{drillTarGZUrl}"
     sudo "curl -L --silent --show-error --fail --connect-timeout 60 --max-time 720 --retry 5 -O  #{drillTarGZUrl}/#{drillTarGZ}"


### PR DESCRIPTION
Updating Drill URL to the most recent version of Drill, from 0.7 to 0.8.