### PR TITLE
Modified install-presto to use symlinks in the PATH variable.

### DIFF
--- a/presto/latest/install-presto
+++ b/presto/latest/install-presto
@@ -273,7 +273,7 @@ def buildCLIWrapper
 	config = []
 
 	config << "#!/bin/bash"
-	config << "export PATH=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.31-2.b13.5.amzn1.x86_64/jre/bin/:$PATH"
+	config << "export PATH=/usr/lib/jvm/jre-1.8.0-openjdk/bin:$PATH"
 	config << "#{@presto_home}/presto-cli-executable.jar $@"
 
 	return config.join("\n")
@@ -283,7 +283,7 @@ def buildPrestoLauncher
 	config = []
 
 	config << "#!/bin/sh -eu"
-	config << "export PATH=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.31-2.b13.5.amzn1.x86_64/jre/bin/:$PATH"
+	config << "export PATH=/usr/lib/jvm/jre-1.8.0-openjdk/bin:$PATH"
 	config << 'exec "$(/usr/bin/dirname "$0")/launcher.py" "$@"'
 
 	return config.join("\n")


### PR DESCRIPTION
Switched the CLI wrapper and presto launcher wrapper from using the full path
name that includes the update version and more to using a symlink that should be
constant for all variations of the Java 1.8 OpenJDK.