### PR TITLE
Support for custom CLI jar and more robust custom binary support

### DIFF
--- a/presto/latest/README.md
+++ b/presto/latest/README.md
@@ -36,7 +36,7 @@ This BA requires that you also install Hive 13 on your cluster as it uses Hive a
 Only tested against AMI 3.3.2 >
 
 ###Changes
-- 09/06/2015 : Changed support for custom binary. No need to repackage like before! Just download from Prestodb.io and upload to S3. (Also typos and documentation corrections)
+- 09/06/2015 : Added custom CLI jar support. Changed support for custom binary: No need to repackage, just download from Prestodb.io and upload to S3. (Also typos and documentation corrections)
 - 07/04/2015 : Added support to specify a Remote MetaStore Service
 - 31/03/2015 : Added Support for Selective CLI installation and to specify your own compiled Presto Binary
 - 26/02/2015 : Added Support for AWS EC2 Roles 

--- a/presto/latest/README.md
+++ b/presto/latest/README.md
@@ -36,6 +36,7 @@ This BA requires that you also install Hive 13 on your cluster as it uses Hive a
 Only tested against AMI 3.3.2 >
 
 ###Changes
+- 09/06/2015 : Changed support for custom binary. No need to repackage like before! Just download from Prestodb.io and upload to S3. (Also typos and documentation corrections)
 - 07/04/2015 : Added support to specify a Remote MetaStore Service
 - 31/03/2015 : Added Support for Selective CLI installation and to specify your own compiled Presto Binary
 - 26/02/2015 : Added Support for AWS EC2 Roles 

--- a/presto/latest/README.md
+++ b/presto/latest/README.md
@@ -14,10 +14,10 @@ Usage: presto-install [OPTIONS]
         --home-dir
     -p [ Hive Metastore Port ],      Ex : 9083 )
         --hive-port
-    -m [ Memory Specified in Java -Xmx Formatting ],
-        --MaxMemory                  Ex : 512M )
-    -n [ Nursery Memory Specified in Java -Xmn Formatting ],
-        --NurseryMem                 Ex : 512M )
+    -m [ Memory (in MB) Specified in Java -Xmx Formatting ],
+        --MaxMemory                  Ex : 512 )
+    -n [ Nursery Memory (in MB) Specified in Java -Xmn Formatting ],
+        --NurseryMem                 Ex : 512 )
     -v [ Version of Presto to Install. See README for supported versions ],
         --version                    Ex : 0.95 )
     -b [ Location of Self Compiled Binary of Presto. See README for details on what package structure must look like. ],

--- a/presto/latest/README.md
+++ b/presto/latest/README.md
@@ -21,9 +21,11 @@ Usage: presto-install [OPTIONS]
     -v [ Version of Presto to Install. See README for supported versions ],
         --version                    Ex : 0.95 )
     -b [ Location of Self Compiled Binary of Presto. See README for details on what package structure must look like. ],
-        --binary                     Ex : s3://mybuctet/compiled/presto-compiled.tar.gz
+        --binary                     Ex : s3://mybucket/compiled/presto-compiled.tar.gz
     -c [ Install Presto-CLI. By default set to true ],
         --install-cli                Ex : false
+    -j [ Location of custom CLI jar (implies -c option). By default, uses CLI of version set with -v ],
+        --cli-jar                    Ex : s3://mybucket/presto-cli.jar
     -M [ Location of Already Running Hive MetaStore. This will stop the BA from launching the Hive MetaStore Service on the Master Instance ],
         --metastore-uri              Ex : thrift://192.168.0.1:9083
     -h, --help                       Display this message

--- a/presto/latest/README.md
+++ b/presto/latest/README.md
@@ -78,12 +78,12 @@ SELECT name,COUNT(name) FROM test GROUP BY name;
 ```
 
 ###Build your own Binary
-We have added the ability for you to compile your own version of Presto and download it from S3.  
-In order for the installation to be successfull the binary must be compressed into a .tar.gz file from within the Presto root folder.  
-In other words, the tarball must not have a folder within it, but rather the final structure of the presto-server folder.  
-The tar file will be extracted to a folder /home/hadoop/.versions/presto-server-user-compiled/ with the command `tar -xf /tmp/presto-server -C /home/hadoop/.versions/presto-server-user-compiled/` 
-It is assumed that after the extraction the etc, plugin, lib and bin folder is in /home/hadoop/.versions/presto-server-user-compiled/  
+We have added the ability for you to compile your own version (or download a pre-compiled version) of Presto and download it from S3. 
+
+In order for the installation to be successful the binary must be compressed into a .tar.gz file with the presto-server-0.xyz directory at the root, **unlike previous version of this script**.
+
+In other words, the tarball **must** have a folder within it, so the tar can be extracted into /home/hadoop/.versions/presto-server-0.xyz/. **This has changed since last version**.
+
 Once extraction is completed all the relevant symlinks will be added to make the folder accessible from /home/hadoop/presto-server/   
-The easiest way to create a Tarball like this is by cd to the folder that contains the bin folder and running the command `tar -zcvf /path/to/tar.tar.gz *`  
 
 

--- a/presto/latest/install-presto
+++ b/presto/latest/install-presto
@@ -72,23 +72,6 @@ def parseOptions
 	return config_options
 end
 
-@parsed = parseOptions
-puts "Installing Presto With Java 1.8 Requirement"
-
-unless @parsed[:binary]
-	@parsed[:binary] = "s3://support.elasticmapreduce/bootstrap-actions/presto/#{@parsed[:version]}/presto-server.tar.gz"
-else
-	@parsed[:version] = "user-compiled"
-end
-
-unless @parsed[:presto_home]
-	@presto_home = "/home/hadoop/.versions/presto-server-#{@parsed[:version]}/"
-else
-	@presto_home = @parsed[:presto_home]
-end
-
-puts "Using Binary From: #{@parsed[:binary]} and installing to #{@presto_home}"
-
 def run(cmd)
   if ! system(cmd) then
     raise "Command failed: #{cmd}"
@@ -267,7 +250,7 @@ def buildCLIWrapper
 	config = []
 
 	config << "#!/bin/bash"
-	config << "export PATH=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.31-2.b13.5.amzn1.x86_64/jre/bin/:$PATH"
+	config << "export PATH=/usr/lib/jvm/jre-1.8.0-openjdk/bin/:$PATH"
 	config << "#{@presto_home}/presto-cli-executable.jar $@"
 
 	return config.join("\n")
@@ -277,7 +260,7 @@ def buildPrestoLauncher
 	config = []
 
 	config << "#!/bin/sh -eu"
-	config << "export PATH=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.31-2.b13.5.amzn1.x86_64/jre/bin/:$PATH"
+	config << "export PATH=/usr/lib/jvm/jre-1.8.0-openjdk/bin/:$PATH"
 	config << 'exec "$(/usr/bin/dirname "$0")/launcher.py" "$@"'
 
 	return config.join("\n")
@@ -290,19 +273,59 @@ def buildLogProperties
 
 	return config.join("\n")
 end
+
+
+@parsed = parseOptions
+puts "Installing Presto With Java 1.8 Requirement"
+
+@version_home =  "/home/hadoop/.versions"
+
+
+unless @parsed[:binary]
+	@parsed[:binary] = "s3://support.elasticmapreduce/bootstrap-actions/presto/#{@parsed[:version]}/presto-server.tar.gz"
+else
+	@parsed[:version] = "user-compiled"
+end
+
+unless @parsed[:presto_home]
+	@presto_home = "#{@version_home}/presto-server-#{@parsed[:version]}/"
+else 
+	@presto_home = @parsed[:presto_home]
+end
+
 	
 # Get The Cluster Information Object
 clusterMetaData = getClusterMetaData
 
-#Now, Lets Fetch The Archives from S3
-#run "curl -kLo /tmp/presto-server.tar.gz http://s3.amazonaws.com/support.elasticmapreduce/bootstrap-actions/presto/0.95/presto-server-0-95.tar.gz"
-run "/home/hadoop/bin/hdfs dfs -get #{@parsed[:binary]} /tmp/presto-server.tar.gz"
-#run "curl -kLo /tmp/presto-cli-0.95-executable.jar http://s3.amazonaws.com/support.elasticmapreduce/bootstrap-actions/presto/0.95/presto-cli-0.95-executable.jar"
+puts "Using Binary From: #{@parsed[:binary]}"
 
-#Extract the Server to its new Home
-run "mkdir -p #{@presto_home}"
+# Now, Lets Fetch The Archives from S3
+run "/home/hadoop/bin/hdfs dfs -get #{@parsed[:binary]} /tmp/presto-server.tar.gz"
+
+
+# Extract the tar
+run "mkdir /tmp/presto-server"
+run "tar -xzvf /tmp/presto-server.tar.gz -C /tmp/presto-server"
+
+# If this is a self-compiled binary, extract temporarily to get the version for presto_home
+if @parsed[:version] == "user-compiled"
+	version = File.basename(Dir["/tmp/presto-server/*"].first)
+	@presto_home = "#{@version_home}/#{version}"
+
+	puts "Installing self-compiled tar to #{@presto_home}"
+
+	# Set up home directory and copy files
+	run "mkdir -p #{@presto_home}"
+	run "mv /tmp/presto-server/#{version}/* #{@presto_home}"
+
+else
+	# Set up home directory and copy files
+	run "mkdir -p #{@presto_home}"
+	run "mv /tmp/presto-server/* #{@presto_home}"
+end
+
 run "mkdir -p #{@presto_home}/etc/catalog/"
-run "tar -xf /tmp/presto-server.tar.gz -C #{@presto_home}"
+
 
 #Move LZO Library Into Presto Libs
 run "/home/hadoop/bin/hdfs dfs -get s3://support.elasticmapreduce/bootstrap-actions/presto/hadoop-lzo-0.4.19.jar #{@presto_home}/plugin/hive-hadoop2/"

--- a/presto/latest/install-presto
+++ b/presto/latest/install-presto
@@ -26,13 +26,13 @@ def parseOptions
 	      		config_options[:port] = port
 	    end
 
-		opt.on("-m",'--MaxMemory [ Memory Specified in Java -Xmx Formatting ]',
-	           "Ex : 512M )") do |xmx_value|
+		opt.on("-m",'--MaxMemory [ Memory (in MB) Specified in Java -Xmx Formatting ]',
+	           "Ex : 512 )") do |xmx_value|
 	      		config_options[:xmx] = xmx_value
 	    end
 
-	    opt.on("-n",'--NurseryMem [ Nursery Memory Specified in Java -Xmn Formatting ]',
-	           "Ex : 512M )") do |nurse|
+	    opt.on("-n",'--NurseryMem [ Nursery Memory (in MB) Specified in Java -Xmn Formatting ]',
+	           "Ex : 512 )") do |nurse|
 	      		config_options[:nurse] = nurse
 	    end
 

--- a/presto/latest/install-presto
+++ b/presto/latest/install-presto
@@ -42,9 +42,15 @@ def parseOptions
 	    end
 
 	    opt.on("-b",'--binary [ Location of Self Compiled Binary of Presto. See README for details on what package structure must look like. ]',
-	           "Ex : s3://mybuctet/compiled/presto-compiled.tar.gz") do |bin|
+	           "Ex : s3://mybucket/compiled/presto-compiled.tar.gz") do |bin|
 	      		config_options[:binary] = bin
 	    end
+
+	    opt.on("-j","--cli-jar [ Location of custom CLI jar (implies -c option) ]",
+	    		"Ex : s3://mybucket/presto-cli.jar") do |cli_jar|
+	    		config_options[:cli_jar] = cli_jar
+	    		config_options[:cli] = true
+    	end
 
 	    opt.on("-c",'--install-cli [ Install Presto-CLI. By default set to true ]',
 	           "Ex : false") do |cli|
@@ -81,7 +87,7 @@ else
 	@presto_home = @parsed[:presto_home]
 end
 
-puts "Uing Binary From: #{@parsed[:binary]} and installing to #{@presto_home}"
+puts "Using Binary From: #{@parsed[:binary]} and installing to #{@presto_home}"
 
 def run(cmd)
   if ! system(cmd) then
@@ -347,7 +353,15 @@ end
 
 #Create Presto Wrapper for CLI if CLI to be installed
 if @parsed[:cli] == true
-	run "/home/hadoop/bin/hdfs dfs -get s3://support.elasticmapreduce/bootstrap-actions/presto/#{@parsed[:version]}/presto-cli-executable.jar /tmp/presto-cli-executable.jar"
+	cli_path = "s3://support.elasticmapreduce/bootstrap-actions/presto/#{@parsed[:version]}/presto-cli-executable.jar"
+
+	if @parsed[:cli_jar]
+		cli_path = @parsed[:cli_jar]
+	end
+
+	puts "Uing CLI From: #{cli_path} and installing to #{@presto_home}"
+
+	run "/home/hadoop/bin/hdfs dfs -get #{cli_path} /tmp/presto-cli-executable.jar"
 	run "cp /tmp/presto-cli-executable.jar #{@presto_home}"
 	run "chmod +x #{@presto_home}/presto-cli-executable.jar"
 	if clusterMetaData['isMaster'] == true
@@ -358,6 +372,7 @@ if @parsed[:cli] == true
 		sudo "ln -s /home/hadoop/presto-cli /usr/bin/"
 	end
 end
+
 
 #Set Symnlinkg For Presto to Home-Folder
 if File.exist? "/home/hadoop/hive/bin/hive-init"


### PR DESCRIPTION
Added support to upload a custom CLI jar that can match your custom binary package. The custom binary no longer requires downloading from Prestodb, repackaging, and then uploading. This script allows a user to skip the unnecessary repackaging step, and detects the extracted directory. Among that are typo fixes and documentation clarification. The memory parameters incorrectly said to specify "512M", where the script was actually appending that M to the parameter in auto-detect cases. 