### PR TITLE
Add cli_jar option that allows for a user-specified CLI jar file

### DIFF
--- a/presto/latest/README.md
+++ b/presto/latest/README.md
@@ -24,6 +24,8 @@ Usage: presto-install [OPTIONS]
         --binary                     Ex : s3://mybuctet/compiled/presto-compiled.tar.gz
     -c [ Install Presto-CLI. By default set to true ],
         --install-cli                Ex : false
+    -j [ Location of custom CLI jar (implies -c option). By default, uses CLI of version set with -v ],
+        --cli-jar                    Ex : s3://mybucket/presto-cli.jar
     -M [ Location of Already Running Hive MetaStore. This will stop the BA from launching the Hive MetaStore Service on the Master Instance ],
         --metastore-uri              Ex : thrift://192.168.0.1:9083
     -h, --help                       Display this message
@@ -34,6 +36,7 @@ This BA requires that you also install Hive 13 on your cluster as it uses Hive a
 Only tested against AMI 3.3.2 >
 
 ###Changes
+- 10/06/2015 : Added custom CLI jar support.
 - 07/04/2015 : Added support to specify a Remote MetaStore Service
 - 31/03/2015 : Added Support for Selective CLI installation and to specify your own compiled Presto Binary
 - 26/02/2015 : Added Support for AWS EC2 Roles 

--- a/presto/latest/install-presto
+++ b/presto/latest/install-presto
@@ -51,6 +51,12 @@ def parseOptions
 	      		config_options[:cli] = cli
 	    end
 
+	    opt.on("-j","--cli-jar [ Location of custom CLI jar (implies -c option) ]",
+	           "Ex : s3://mybucket/presto-cli.jar") do |cli_jar|
+	      		config_options[:cli_jar] = cli_jar
+	      		config_options[:cli] = true
+	    end
+
 	    opt.on("-M",'--metastore-uri [ Location of Already Running Hive MetaStore. This will stop the BA from launching the Hive MetaStore Service on the Master Instance ]',
 	           "Ex : thrift://192.168.0.1:9083") do |metaURI|
 	      		config_options[:metaURI] = metaURI
@@ -82,6 +88,12 @@ else
 end
 
 puts "Uing Binary From: #{@parsed[:binary]} and installing to #{@presto_home}"
+
+unless @parsed[:cli_jar]
+	@cli_jar = "s3://support.elasticmapreduce/bootstrap-actions/presto/#{@parsed[:version]}/presto-cli-executable.jar"
+else
+	@cli_jar = @parsed[:cli_jar]
+end
 
 def run(cmd)
   if ! system(cmd) then
@@ -347,7 +359,7 @@ end
 
 #Create Presto Wrapper for CLI if CLI to be installed
 if @parsed[:cli] == true
-	run "/home/hadoop/bin/hdfs dfs -get s3://support.elasticmapreduce/bootstrap-actions/presto/#{@parsed[:version]}/presto-cli-executable.jar /tmp/presto-cli-executable.jar"
+	run "/home/hadoop/bin/hdfs dfs -get #{@cli_jar} /tmp/presto-cli-executable.jar"
 	run "cp /tmp/presto-cli-executable.jar #{@presto_home}"
 	run "chmod +x #{@presto_home}/presto-cli-executable.jar"
 	if clusterMetaData['isMaster'] == true


### PR DESCRIPTION
This is inspired by the work of @louiswilliams in PR #119, but is limited to adding custom CLI jar support and tries to mimic the way the existing code handles options.