### PR TITLE
Increment Elasticsearch and Kibana versions.

### DIFF
--- a/elasticsearch/elasticsearch_install.rb
+++ b/elasticsearch/elasticsearch_install.rb
@@ -25,7 +25,7 @@ sudo("cp /mnt/var/lib/instance-controller/extraInstanceData.json" +
 @run_dir = "/home/hadoop/elasticsearch/"
 # this is where additional logs are sent in case terminal output needs to be caught
 @log_dir = "/home/hadoop/elasticsearch/"
-@elasticsearch_version = "1.5.1"
+@elasticsearch_version = "1.6.0"
 @elasticsearch_port_master = 9200
 @elasticsearch_port_slaves = 9202
 

--- a/elasticsearch/kibananginx_install.rb
+++ b/elasticsearch/kibananginx_install.rb
@@ -12,7 +12,7 @@ def sudo(cmd)
 end
 
 @is_master = Emr::JsonInfoFile.new('instance')['isMaster'].to_s == 'true'
-@kibana_version = "4.0.2-linux-x64"
+@kibana_version = "4.1.0-linux-x64"
 @target_dir = "/home/hadoop/kibana/"
 @nginx_dir = "/etc/nginx/"
 @es_port_num = 9200


### PR DESCRIPTION
Currently, the tutorial described [here](https://blogs.aws.amazon.com/bigdata/post/Tx1E8WC98K4TB7T/Getting-Started-with-Elasticsearch-and-Kibana-on-Amazon-EMR) doesn't work. Incrementing both the Elasticsearch and Kibana versions to the latest releases makes everything work just fine. 