### PR TITLE
Add opt-out for Spark Ganglia metrics

### DIFF
--- a/spark/install-spark
+++ b/spark/install-spark
@@ -7,7 +7,8 @@ set -x
 #   -c <s3_config_file>  - The install-spark config file which tells the script where to find version specific install scripts and binaries, defaults to AWS provided config
 #   -v <version>      - Ability to select a specific Spark build version as avialable via the config file, see https://github.com/awslabs/emr-bootstrap-actions/blob/master/spark/README.md
 #   -b <buildid>      - May be used by the versioned Spark install script in order to request a specific build
-#   -g		      - Enables Ganglia metrics (deprecated - Ganglia metrics will now be configured as long as Ganglia app is installed)
+#   -g		      - Enables Ganglia metrics (deprecated - Ganglia metrics will now be configured as long as Ganglia app is installed, unless -n flag is passed)
+#   -n		      - Disables Ganglia metrics (include if you have Ganglia installed but do *not* want Spark Ganglia metrics configured)
 #   -x                - Sets the default Spark config for dedictate Spark job utilization [1 executor per node, all vcore and memory, all core nodes]
 #   -u <s3path>       - Add the jars in the given S3 path to spark classpath in the user-provided directory (ahead of all other dependencies) 
 #   -a		      - (Use cautiously) Place spark-assembly-*.jar ahead of all system jars on spark classpath
@@ -88,6 +89,8 @@ USE_EMR_HIVE_JARS=0
 
 SPARK_DEFAULTS_CONF_KEY_VALUES=()
 
+SPARK_GANGLIA_METRICS=1
+
 #process command line arguments
 while getopts "c:v:b:xu:al:hd:" opt; do
   case $opt in
@@ -117,6 +120,9 @@ while getopts "c:v:b:xu:al:hd:" opt; do
       ;;
     d)
       SPARK_DEFAULTS_CONF_KEY_VALUES+=($OPTARG)
+      ;;
+    n)
+      SPARK_GANGLIA_METRICS=0
       ;;
   esac
 done
@@ -274,7 +280,7 @@ touch /mnt/sparkinstalled
 # field7 - (optional) s3 path to the script executed when "-g" argument is used to install ganlia, defaults to AWS provided version if empty
 
 
-if [ -e /usr/sbin/gmond ] # If Ganglia is installed
+if [ $SPARK_GANGLIA_METRICS -eq 1 ] && [ -e /usr/sbin/gmond ] # If Ganglia is installed
 then
 	#We need the ganglia script
 	if [ "${CONFIG_FIELDS_ARRAY[6]}" == "" ]


### PR DESCRIPTION
This is necessary because some customers, especially those with long-running
clusters, might not want to have Spark Ganglia metrics enabled even if they have
Ganglia installed, as the per-executor metrics that are created can fill up the
root partition too quickly.