### PR TITLE
Adding IPython Notebook with PySpark Support

### DIFF
--- a/ipython-notebook/install-ipython-notebook-pyspark
+++ b/ipython-notebook/install-ipython-notebook-pyspark
@@ -1,0 +1,62 @@
+#!/bin/bash -ex
+
+if grep isMaster /mnt/var/lib/info/instance.json | grep true; then
+    # Setup virtualenv
+    mkdir -p /home/hadoop/ipython
+    cd /home/hadoop/ipython
+    sudo pip install virtualenv
+    /usr/local/bin/virtualenv -p /usr/bin/python2.7 ENV
+    source ENV/bin/activate
+
+    # Install IPython
+    pip install "ipython[notebook]==3.2"
+    pip install numpy matplotlib
+
+    # Create PySpark profile for IPython
+    ipython profile create pyspark
+
+    cat <<'EOF' > /home/hadoop/.ipython/profile_pyspark/ipython_notebook_config.py
+c = get_config()
+
+c.NotebookApp.ip = '*'
+c.NotebookApp.open_browser = False
+c.NotebookApp.port = 8888
+EOF
+
+    cat <<'EOF' > /home/hadoop/.ipython/profile_pyspark/startup/pyspark-setup.py
+import os
+import sys
+
+spark_home = os.environ.get('SPARK_HOME', None)
+if not spark_home:
+    raise ValueError('SPARK_HOME environment variable is not set')
+
+sys.path.insert(0, os.path.join(spark_home, 'python'))
+sys.path.insert(0, os.path.join(spark_home, 'python/lib/py4j-0.8.2.1-src.zip'))
+execfile(os.path.join(spark_home, 'python/pyspark/shell.py'))
+EOF
+
+    # Prepare PySpark submit arguments
+    SPARK_DEFAULTS=/usr/lib/spark/conf/spark-defaults.conf
+    declare -a PYSPARK_SUBMIT_ARGS
+    if [ -f $SPARK_DEFAULTS ]; then
+        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
+            "--master yarn")
+        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
+            "--deploy-mode client")
+        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
+            $(grep spark.executor.instances $SPARK_DEFAULTS | awk '{print "--num-executors " $2}'))
+        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
+            $(grep spark.executor.cores $SPARK_DEFAULTS | awk '{print "--executor-cores " $2}'))
+        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
+            $(grep spark.executor.memory $SPARK_DEFAULTS | awk '{print "--executor-memory " $2}'))
+        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
+            "pyspark-shell")
+    fi
+
+    echo "SPARK_HOME=$SPARK_HOME"
+    echo "PYSPARK_SUBMIT_ARGS=${PYSPARK_SUBMIT_ARGS[@]}"
+    export SPARK_HOME=/usr/lib/spark
+    export PYSPARK_SUBMIT_ARGS=${PYSPARK_SUBMIT_ARGS[@]}
+    ipython notebook --profile=pyspark &> /mnt/var/log/ipython_notebook.log &
+fi

--- a/ipython-notebook/install-ipython-notebook-pyspark
+++ b/ipython-notebook/install-ipython-notebook-pyspark
@@ -17,7 +17,6 @@ if grep isMaster /mnt/var/lib/info/instance.json | grep true; then
 
     cat <<'EOF' > /home/hadoop/.ipython/profile_pyspark/ipython_notebook_config.py
 c = get_config()
-
 c.NotebookApp.ip = '*'
 c.NotebookApp.open_browser = False
 c.NotebookApp.port = 8888
@@ -26,37 +25,16 @@ EOF
     cat <<'EOF' > /home/hadoop/.ipython/profile_pyspark/startup/pyspark-setup.py
 import os
 import sys
-
 spark_home = os.environ.get('SPARK_HOME', None)
 if not spark_home:
     raise ValueError('SPARK_HOME environment variable is not set')
-
 sys.path.insert(0, os.path.join(spark_home, 'python'))
 sys.path.insert(0, os.path.join(spark_home, 'python/lib/py4j-0.8.2.1-src.zip'))
 execfile(os.path.join(spark_home, 'python/pyspark/shell.py'))
 EOF
-
-    # Prepare PySpark submit arguments
-    SPARK_DEFAULTS=/usr/lib/spark/conf/spark-defaults.conf
-    declare -a PYSPARK_SUBMIT_ARGS
-    if [ -f $SPARK_DEFAULTS ]; then
-        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
-            "--master yarn")
-        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
-            "--deploy-mode client")
-        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
-            $(grep spark.executor.instances $SPARK_DEFAULTS | awk '{print "--num-executors " $2}'))
-        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
-            $(grep spark.executor.cores $SPARK_DEFAULTS | awk '{print "--executor-cores " $2}'))
-        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
-            $(grep spark.executor.memory $SPARK_DEFAULTS | awk '{print "--executor-memory " $2}'))
-        PYSPARK_SUBMIT_ARGS=("${PYSPARK_SUBMIT_ARGS[@]}" \
-            "pyspark-shell")
-    fi
-
-    echo "SPARK_HOME=$SPARK_HOME"
-    echo "PYSPARK_SUBMIT_ARGS=${PYSPARK_SUBMIT_ARGS[@]}"
     export SPARK_HOME=/usr/lib/spark
-    export PYSPARK_SUBMIT_ARGS=${PYSPARK_SUBMIT_ARGS[@]}
+    export PYSPARK_SUBMIT_ARGS=pyspark-shell
+    echo "SPARK_HOME=$SPARK_HOME"
+    echo "PYSPARK_SUBMIT_ARGS=$PYSPARK_SUBMIT_ARGS"
     ipython notebook --profile=pyspark &> /mnt/var/log/ipython_notebook.log &
 fi


### PR DESCRIPTION
Added script installing IPython Notebook with PySpark support. Inspired by the install-ipython-notebook script that already existed. Verified on EMR release 4.x cluster.