### PR TITLE
Fixed regular expression checking for S3

### DIFF
--- a/utilities/run-if
+++ b/utilities/run-if
@@ -72,7 +72,7 @@ def download_and_execute_command(command, args)
   execute_name = command
   
   # If the command starts with s3:// or s3n://
-  if command.match(/s3[n]{0,1}:\/\/.*/) then
+  if command.match(^/s3[n]{0,1}:\/\/.*/) then
     puts "Attempting to download file '#{command}'"
     system("/home/hadoop/bin/hadoop fs -copyToLocal #{command} ./")
     

--- a/utilities/run-if
+++ b/utilities/run-if
@@ -72,7 +72,7 @@ def download_and_execute_command(command, args)
   execute_name = command
   
   # If the command starts with s3://, s3n:// or s3a://
-  if command.match(^s3[n|a]{0,1}:\/\/.*) then
+  if command.match(/^s3[n|a]{0,1}:\/\/.*/) then
     puts "Attempting to download file '#{command}'"
     system("/home/hadoop/bin/hadoop fs -copyToLocal #{command} ./")
     

--- a/utilities/run-if
+++ b/utilities/run-if
@@ -72,7 +72,7 @@ def download_and_execute_command(command, args)
   execute_name = command
   
   # If the command starts with s3:// or s3n://
-  if command.match(^/s3[n]{0,1}:\/\/.*/) then
+  if command.match(/^s3[n]{0,1}:\/\/.*/) then
     puts "Attempting to download file '#{command}'"
     system("/home/hadoop/bin/hadoop fs -copyToLocal #{command} ./")
     

--- a/utilities/run-if
+++ b/utilities/run-if
@@ -71,8 +71,8 @@ def download_and_execute_command(command, args)
   file_name = command
   execute_name = command
   
-  # If the command starts with s3:// or s3n://
-  if command.match(/^s3[n]{0,1}:\/\/.*/) then
+  # If the command starts with s3://, s3n:// or s3a://
+  if command.match(^s3[n|a]{0,1}:\/\/.*) then
     puts "Attempting to download file '#{command}'"
     system("/home/hadoop/bin/hadoop fs -copyToLocal #{command} ./")
     


### PR DESCRIPTION
Changed regular expression to ensure s3: is at the start of the line and added s3a:// as well.

$ cat test.rb
string = [ "s3a://mombergm.store", "s3n://mombergm.store", "s3n://mombergm.store", "s3://mombergm.store", "s3:mombergm.store", "mombergm.store" , "ant s3://mombergm.store"]

string.each do | test |
	res = test.match(/^s3[n|a]{0,1}:\/\/.*/)
	if res
		puts "#{test} Matched"
	else
		puts "#{test} Did not Match"
	end
end

$ ruby test.rb 
s3a://mombergm.store Matched
s3n://mombergm.store Matched
s3n://mombergm.store Matched
s3://mombergm.store Matched
s3:mombergm.store Did not Match
mombergm.store Did not Match
ant s3://mombergm.store Did not Match
$ 
